### PR TITLE
Fix PSI access threading issues in CsvTableModelSwing

### DIFF
--- a/src/main/java/net/seesharpsoft/intellij/plugins/csv/editor/table/swing/CsvTableModelSwing.java
+++ b/src/main/java/net/seesharpsoft/intellij/plugins/csv/editor/table/swing/CsvTableModelSwing.java
@@ -26,6 +26,9 @@ import java.util.concurrent.TimeUnit;
 
 public class CsvTableModelSwing extends CsvTableModelBase<CsvTableEditor> implements TableModel {
 
+    /**
+     * List of listeners
+     */
     protected EventListenerList listenerList = new EventListenerList();
 
     protected ScheduledFuture<?> delayedUpdate;
@@ -62,7 +65,10 @@ public class CsvTableModelSwing extends CsvTableModelBase<CsvTableEditor> implem
     }
 
     protected void fireTableChanged(TableModelEvent e) {
+        // Guaranteed to return a non-null array
         Object[] listeners = listenerList.getListenerList();
+        // Process the listeners last to first, notifying
+        // those that are interested in this event
         for (int i = listeners.length - 2; i >= 0; i -= 2) {
             if (listeners[i] == TableModelListener.class) {
                 ((TableModelListener) listeners[i + 1]).tableChanged(e);
@@ -90,6 +96,10 @@ public class CsvTableModelSwing extends CsvTableModelBase<CsvTableEditor> implem
         listenerList.remove(TableModelListener.class, l);
     }
 
+    /**
+     * Gets header name for a given column, with index formatting.
+     * PSI access is wrapped in a read action for thread safety.
+     */
     @Override
     public String getColumnName(int column) {
         return ApplicationManager.getApplication().runReadAction((Computable<String>) () -> {


### PR DESCRIPTION
 ```java
getColumnName(int column)
```
 now wraps all PSI access in
```java
 ApplicationManager.getApplication().runReadAction
 ```
 This ensures that reading PSI elements occurs safely within the required read action context, fixing runtime errors about improper thread access.
 resolves exceptions like: ```Read access is allowed from inside read-action only```
 
 
 
 log:
 ```log
 
com.intellij.openapi.diagnostic.RuntimeExceptionWithAttachments: Read access is allowed from inside read-action only (see Application.runReadAction()); If you access or modify model on EDT consider wrapping your code in WriteIntentReadAction ; see https://jb.gg/ij-platform-threading for details
Current thread: Thread[#44,AWT-EventQueue-0,6,InnocuousThreadGroup] 2058101782 (EventQueue.isDispatchThread()=true)
SystemEventQueueThread: (same)
	at com.intellij.util.concurrency.ThreadingAssertions.createThreadAccessException(ThreadingAssertions.java:257)
	at com.intellij.util.concurrency.ThreadingAssertions.softAssertReadAccess(ThreadingAssertions.java:173)
	at com.intellij.openapi.application.impl.ApplicationImpl.assertReadAccessAllowed(ApplicationImpl.java:1171)
	at com.intellij.psi.impl.source.tree.TreeElement.assertReadAccessAllowed(TreeElement.java:437)
	at com.intellij.psi.impl.source.tree.CompositeElement.textToCharArray(CompositeElement.java:243)
	at com.intellij.psi.impl.source.tree.CompositeElement.getText(CompositeElement.java:226)
	at com.intellij.extapi.psi.ASTDelegatePsiElement.getText(ASTDelegatePsiElement.java:136)
	at net.seesharpsoft.intellij.plugins.csv.editor.table.swing.CsvTableModelSwing.getColumnName(CsvTableModelSwing.java:104)
	at java.desktop/javax.swing.JTable.addColumn(JTable.java:2853)
	at java.desktop/javax.swing.JTable.createDefaultColumnsFromModel(JTable.java:1356)
	at java.desktop/javax.swing.JTable.tableChanged(JTable.java:4454)
	at net.seesharpsoft.intellij.plugins.csv.editor.table.swing.CsvTableEditorSwing.afterTableModelUpdate(CsvTableEditorSwing.java:174)
	at net.seesharpsoft.intellij.plugins.csv.editor.table.swing.CsvTableModelSwing.doNotifyUpdate(CsvTableModelSwing.java:62)
	at com.intellij.util.concurrency.ChildContext$runInChildContext$1.invoke(propagation.kt:167)
	at com.intellij.util.concurrency.ChildContext$runInChildContext$1.invoke(propagation.kt:167)
	at com.intellij.util.concurrency.ChildContext.runInChildContext(propagation.kt:173)
	at com.intellij.util.concurrency.ChildContext.runInChildContext(propagation.kt:167)
	at com.intellij.util.concurrency.ContextRunnable.run(ContextRunnable.java:27)
	at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:318)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:781)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:728)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:722)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:87)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:750)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.kt:595)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.kt:488)
	at com.intellij.ide.IdeEventQueue.dispatchEvent$lambda$12$lambda$11$lambda$10$lambda$9(IdeEventQueue.kt:313)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:865)
	at com.intellij.ide.IdeEventQueue.dispatchEvent$lambda$12$lambda$11$lambda$10(IdeEventQueue.kt:312)
	at com.intellij.ide.IdeEventQueueKt.performActivity$lambda$3(IdeEventQueue.kt:974)
	at com.intellij.openapi.application.TransactionGuardImpl.performActivity(TransactionGuardImpl.java:110)
	at com.intellij.ide.IdeEventQueueKt.performActivity(IdeEventQueue.kt:974)
	at com.intellij.ide.IdeEventQueue.dispatchEvent$lambda$12(IdeEventQueue.kt:307)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.kt:347)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:207)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:128)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:117)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:105)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:92)
```