### PR TITLE
Release 4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,23 +10,19 @@
 
 ### Fixed
 
-## 4.2.3 - Jun 21, 2026
-
-### Fixed
-
-- branch code for retrieving plugin info for legacy vs EAP version
-
-## 4.2.2 - Jun 21, 2026
+## 4.3.0 - Jun 21, 2026
 
 ### Changed
 
 - replaced deprecated function ReadAction.compute(ThrowableComputable)
 - replaced internal function PluginManagerCore.getPlugin(PluginId)
-
-## 4.2.1 - May 24, 2026
+- branch code for retrieving plugin info for legacy vs EAP version
 
 ### Fixed
 
+- Fixed `NoClassDefFoundError` in `CsvEditorSettings`
+- Fixed `java.lang.Throwable: ... Class initialization must not depend on services` by removing service access from class initializers and constructors
+- Fixed a `PluginException` (caused by `java.lang.IllegalArgumentException`) that occurred during early plugin initialization
 - PluginException: Invalid PSI Element CsvFile when file is invalidated during annotation, intention actions, or inspection fixes #964
 - IncorrectOperationException: parent CsvTableEditorSwing already disposed when async PsiTreeChangeListener registration completes #962
 - Modified `CsvPlugin.openLink` to use `executeOnPooledThread` for setting dialogs #953

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 
 pluginName=CSV Editor
 pluginId=net.seesharpsoft.intellij.plugins.csv
-pluginVersion=4.2.3
+pluginVersion=4.3.0
 
 pluginSinceBuild=242
 

--- a/src/main/java/net/seesharpsoft/intellij/plugins/csv/CsvPluginDescriptorRetriever.java
+++ b/src/main/java/net/seesharpsoft/intellij/plugins/csv/CsvPluginDescriptorRetriever.java
@@ -14,9 +14,15 @@ public final class CsvPluginDescriptorRetriever {
     private static final PluginId PLUGIN_ID = PluginId.getId("net.seesharpsoft.intellij.plugins.csv");
 
     public static IdeaPluginDescriptor getPluginDescriptor() {
-        BuildNumber buildNumber = ApplicationInfo.getInstance().getBuild();
+        BuildNumber buildNumber = null;
+        try {
+            buildNumber = ApplicationInfo.getInstance().getBuild();
+        } catch (Exception e) {
+            LOG.debug("Failed to retrieve build number", e);
+        }
+
         // PluginDetailsService is available from 2026.2, which roughly corresponds to build 262
-        if (buildNumber.getBaselineVersion() >= 262) {
+        if (buildNumber != null && buildNumber.getBaselineVersion() >= 262) {
             try {
                 Class<?> serviceClass = Class.forName("com.intellij.ide.plugins.PluginDetailsService");
                 Method getInstanceMethod = serviceClass.getMethod("getInstance");

--- a/src/main/java/net/seesharpsoft/intellij/plugins/csv/CsvPluginManager.java
+++ b/src/main/java/net/seesharpsoft/intellij/plugins/csv/CsvPluginManager.java
@@ -11,7 +11,12 @@ public final class CsvPluginManager {
 
     public static ResourceBundle getResourceBundle() {
         if (_resourceBundle == null) {
-            _resourceBundle = DynamicBundle.getPluginBundle(getPluginDescriptor());
+            IdeaPluginDescriptor descriptor = getPluginDescriptor();
+            if (descriptor != null) {
+                _resourceBundle = DynamicBundle.getPluginBundle(descriptor);
+            } else {
+                return ResourceBundle.getBundle("localization.CsvEditorResources");
+            }
         }
         return _resourceBundle;
     }

--- a/src/main/java/net/seesharpsoft/intellij/plugins/csv/highlighter/CsvTextAttributeKeys.java
+++ b/src/main/java/net/seesharpsoft/intellij/plugins/csv/highlighter/CsvTextAttributeKeys.java
@@ -34,26 +34,36 @@ public final class CsvTextAttributeKeys {
             createTextAttributesKey("CSV_BAD_CHARACTER", HighlighterColors.BAD_CHARACTER);
 
     public static final Integer MAX_COLUMN_COLORING_COLORS = 10;
-    public static final AttributesDescriptor[] DESCRIPTORS;
+    private static AttributesDescriptor[] DESCRIPTORS = null;
+
+    public static AttributesDescriptor[] getDescriptors() {
+        if (DESCRIPTORS == null) {
+            List<AttributesDescriptor> attributesDescriptors = new ArrayList<>();
+            ResourceBundle bundle = getResourceBundle();
+            attributesDescriptors.add(new AttributesDescriptor(bundle.getString("color.attribute.separator"), CsvTextAttributeKeys.COMMA));
+            attributesDescriptors.add(new AttributesDescriptor(bundle.getString("color.attribute.quote"), CsvTextAttributeKeys.QUOTE));
+            attributesDescriptors.add(new AttributesDescriptor(bundle.getString("color.attribute.text"), CsvTextAttributeKeys.TEXT));
+            attributesDescriptors.add(new AttributesDescriptor(bundle.getString("color.attribute.text.escaped"), CsvTextAttributeKeys.ESCAPED_TEXT));
+            attributesDescriptors.add(new AttributesDescriptor(bundle.getString("color.attribute.comment"), CsvTextAttributeKeys.COMMENT));
+
+            for (int i = 0; i < MAX_COLUMN_COLORING_COLORS; ++i) {
+                TextAttributesKey textAttributesKey = COLUMN_COLORING_ATTRIBUTES.get(i);
+                attributesDescriptors.add(new AttributesDescriptor(String.format(bundle.getString("color.attribute.column.nr"), i + 1), textAttributesKey));
+            }
+            DESCRIPTORS = attributesDescriptors.toArray(new AttributesDescriptor[0]);
+        }
+        return DESCRIPTORS;
+    }
+
     private static final List<TextAttributesKey> COLUMN_COLORING_ATTRIBUTES;
     private static final Key<List<TextAttributes>> COLUMN_COLORING_TEXT_ATTRIBUTES = Key.create("CSV_PLUGIN_COLUMN_COLORING_ATTRIBUTES");
 
     static {
-        List<AttributesDescriptor> attributesDescriptors = new ArrayList<>();
-        ResourceBundle bundle = getResourceBundle();
-        attributesDescriptors.add(new AttributesDescriptor(bundle.getString("color.attribute.separator"), CsvTextAttributeKeys.COMMA));
-        attributesDescriptors.add(new AttributesDescriptor(bundle.getString("color.attribute.quote"), CsvTextAttributeKeys.QUOTE));
-        attributesDescriptors.add(new AttributesDescriptor(bundle.getString("color.attribute.text"), CsvTextAttributeKeys.TEXT));
-        attributesDescriptors.add(new AttributesDescriptor(bundle.getString("color.attribute.text.escaped"), CsvTextAttributeKeys.ESCAPED_TEXT));
-        attributesDescriptors.add(new AttributesDescriptor(bundle.getString("color.attribute.comment"), CsvTextAttributeKeys.COMMENT));
-
         COLUMN_COLORING_ATTRIBUTES = new ArrayList<>();
         for (int i = 0; i < MAX_COLUMN_COLORING_COLORS; ++i) {
             TextAttributesKey textAttributesKey = createTextAttributesKey(String.format("CSV_PLUGIN_COLUMN_COLORING_ATTRIBUTE_%d", i), CsvTextAttributeKeys.TEXT);
             COLUMN_COLORING_ATTRIBUTES.add(textAttributesKey);
-            attributesDescriptors.add(new AttributesDescriptor(String.format(bundle.getString("color.attribute.column.nr"), i + 1), textAttributesKey));
         }
-        DESCRIPTORS = attributesDescriptors.toArray(new AttributesDescriptor[0]);
     }
 
     public static TextAttributesKey getTextAttributesKeys(int columnIndex) {

--- a/src/main/java/net/seesharpsoft/intellij/plugins/csv/settings/CsvColorSettings.java
+++ b/src/main/java/net/seesharpsoft/intellij/plugins/csv/settings/CsvColorSettings.java
@@ -48,7 +48,7 @@ public class CsvColorSettings implements ColorSettingsPage {
     @NotNull
     @Override
     public AttributesDescriptor[] getAttributeDescriptors() {
-        return CsvTextAttributeKeys.DESCRIPTORS;
+        return CsvTextAttributeKeys.getDescriptors();
     }
 
     @NotNull

--- a/src/main/java/net/seesharpsoft/intellij/plugins/csv/settings/CsvEditorSettings.java
+++ b/src/main/java/net/seesharpsoft/intellij/plugins/csv/settings/CsvEditorSettings.java
@@ -47,13 +47,17 @@ public class CsvEditorSettings implements PersistentStateComponent<CsvEditorSett
         TEXT_ONLY("settings.editor.prio.text_only");
 
         private final String resourceKey;
+        private String display;
 
         private EditorPrio(String resourceKey) {
             this.resourceKey = resourceKey;
         }
 
         public String getDisplay() {
-            return getLocalizedText(resourceKey);
+            if (display == null) {
+                display = getLocalizedText(resourceKey);
+            }
+            return display;
         }
     }
 
@@ -62,13 +66,17 @@ public class CsvEditorSettings implements PersistentStateComponent<CsvEditorSett
         SIMPLE("settings.editor.coloring.simple");
 
         private final String resourceKey;
+        private String display;
 
         ValueColoring(String resourceKey) {
             this.resourceKey = resourceKey;
         }
 
         public String getDisplay() {
-            return getLocalizedText(this.resourceKey);
+            if (display == null) {
+                display = getLocalizedText(this.resourceKey);
+            }
+            return display;
         }
     }
 

--- a/src/main/java/net/seesharpsoft/intellij/plugins/csv/settings/CsvEditorSettings.java
+++ b/src/main/java/net/seesharpsoft/intellij/plugins/csv/settings/CsvEditorSettings.java
@@ -42,33 +42,33 @@ public class CsvEditorSettings implements PersistentStateComponent<CsvEditorSett
     private static final CsvEditorSettings STATIC_TEST_INSTANCE = new CsvEditorSettings();
 
     public enum EditorPrio {
-        TEXT_FIRST(getLocalizedText("settings.editor.prio.text_first")),
-        TABLE_FIRST(getLocalizedText("settings.editor.prio.table_first")),
-        TEXT_ONLY(getLocalizedText("settings.editor.prio.text_only"));
+        TEXT_FIRST("settings.editor.prio.text_first"),
+        TABLE_FIRST("settings.editor.prio.table_first"),
+        TEXT_ONLY("settings.editor.prio.text_only");
 
-        private final String label;
-        
-        private EditorPrio(String label) {
-            this.label = label;
+        private final String resourceKey;
+
+        private EditorPrio(String resourceKey) {
+            this.resourceKey = resourceKey;
         }
 
         public String getDisplay() {
-            return label;
+            return getLocalizedText(resourceKey);
         }
     }
 
     public enum ValueColoring {
-        RAINBOW(getLocalizedText("settings.editor.coloring.rainbow")),
-        SIMPLE(getLocalizedText("settings.editor.coloring.simple"));
+        RAINBOW("settings.editor.coloring.rainbow"),
+        SIMPLE("settings.editor.coloring.simple");
 
-        private final String display;
+        private final String resourceKey;
 
-        ValueColoring(String displayArg) {
-            this.display = displayArg;
+        ValueColoring(String resourceKey) {
+            this.resourceKey = resourceKey;
         }
 
         public String getDisplay() {
-            return this.display;
+            return getLocalizedText(this.resourceKey);
         }
     }
 

--- a/src/test/java/net/seesharpsoft/intellij/plugins/csv/settings/CsvEditorSettingsTest.java
+++ b/src/test/java/net/seesharpsoft/intellij/plugins/csv/settings/CsvEditorSettingsTest.java
@@ -21,4 +21,13 @@ public class CsvEditorSettingsTest extends CsvBasePlatformTestCase {
 
         assertEquals(CsvEditorSettings.ESCAPE_CHARACTER_DEFAULT, CsvHelper.getEscapeCharacter(myFixture.getFile()));
     }
+
+    public void testGetDisplayDoesNotThrow() {
+        for (CsvEditorSettings.EditorPrio prio : CsvEditorSettings.EditorPrio.values()) {
+            assertNotNull(prio.getDisplay());
+        }
+        for (CsvEditorSettings.ValueColoring coloring : CsvEditorSettings.ValueColoring.values()) {
+            assertNotNull(coloring.getDisplay());
+        }
+    }
 }


### PR DESCRIPTION
## 4.3.0 - Jun 21, 2026

### Changed

- replaced deprecated function ReadAction.compute(ThrowableComputable)
- replaced internal function PluginManagerCore.getPlugin(PluginId)
- branch code for retrieving plugin info for legacy vs EAP version

### Fixed

- Fixed `NoClassDefFoundError` in `CsvEditorSettings`
- Fixed `java.lang.Throwable: ... Class initialization must not depend on services` by removing service access from class initializers and constructors
- Fixed a `PluginException` (caused by `java.lang.IllegalArgumentException`) that occurred during early plugin initialization
- PluginException: Invalid PSI Element CsvFile when file is invalidated during annotation, intention actions, or inspection fixes #964
- IncorrectOperationException: parent CsvTableEditorSwing already disposed when async PsiTreeChangeListener registration completes #962
- Modified `CsvPlugin.openLink` to use `executeOnPooledThread` for setting dialogs #953
- Modified `CsvEditorSettings.java` to ensure all getter methods access the internal `OptionSet` directly instead of calling `getState()` #954
- GithubStatusCodeException: 422 Unprocessable Entity - Validation Failed during issue submission #920